### PR TITLE
Added query parameter example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ request('http://www.google.com', function (error, response, body) {
 
 ## Table of contents
 
-- [Query strings](#query-strings
+- [Query strings](#query-strings)
 - [Streaming](#streaming)
 - [Promises & Async/Await](#promises--asyncawait)
 - [Forms](#forms)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ request('http://www.google.com', function (error, response, body) {
 
 ## Table of contents
 
-- [Query strings](#query-strings)
+- [Query parameters](#query-parameters)
 - [Streaming](#streaming)
 - [Promises & Async/Await](#promises--asyncawait)
 - [Forms](#forms)
@@ -48,9 +48,9 @@ lots of [usage examples](#examples) and several
 
 ---
 
-## Query strings
+## Query parameters
 
-You can easily add a query string (represented by a dictionary of parameters) to a request:
+You can easily add query parameters to a request:
 
 ```js
 // Requests http://example.com/myservice?key=value&n=2

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ request('http://www.google.com', function (error, response, body) {
 
 ## Table of contents
 
+- [Query strings](#query-strings
 - [Streaming](#streaming)
 - [Promises & Async/Await](#promises--asyncawait)
 - [Forms](#forms)
@@ -47,6 +48,16 @@ lots of [usage examples](#examples) and several
 
 ---
 
+## Query strings
+
+You can easily add a query string (represented by a dictionary of parameters) to a request:
+
+```js
+// Requests http://example.com/myservice?key=value&n=2
+request.get({url: 'http://example.com/myservice', qs: {key: 'value', n: 2}, function(error, response, body) {
+    // ...
+})
+```
 
 ## Streaming
 


### PR DESCRIPTION
This is a README-only update, so re-testing is not neccessary.

I noticed that an example for requests with query parameters was missing although this is one of the most common tasks for HTTP request libraries.